### PR TITLE
Allow override default of lvol Shrink (True) for idempotency

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ These variables must be defined (defaults aren't provided):
 
 Optional variables:
 
+- `lvm_shrink`: Shrink if current size is higher than size requested (default: True)
 - `lvm_lvopts`: Logical volume creation options (default: None)
 
 Author Information

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   description: Create a formatted LVM volume
   company: Open Microscopy Environment
   license: BSD
-  min_ansible_version: 2.1
+  min_ansible_version: 2.2
   platforms:
   - name: EL
     versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,7 @@
     vg: "{{ lvm_vgname }}"
     lv: "{{ lvm_lvname }}"
     size: "{{ lvm_lvsize }}"
+    shrink: "{{ lvm_shrink | default(True) }}"
     opts: "{{ lvm_lvopts | default(None) }}"
 
 - name: storage | format


### PR DESCRIPTION
cf https://github.com/ansible/ansible-modules-extras/issues/428#issuecomment-222773762

Despite manually specifying a file size, reruns of a playbook fail on the lvm-partition role runs with e.g.

`fatal: [ome-demoserver.openmicroscopy.org]: FAILED! => {"changed": false, "failed": true, "msg": "Sorry, no shrinking of root without force=yes"}`