### PR TITLE
Make the mount options configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Optional variables:
 
 - `lvm_shrink`: Shrink if current size is higher than size requested (default: True)
 - `lvm_lvopts`: Logical volume creation options (default: None)
+- `lvm_lvmount_dump`: Mount option (dump) for the filesystem mount point (default: 1)
+- `lvm_lvmount_passno`: Mount option (passno) for the filesystem mount point (default: 2)
+
 
 Author Information
 ------------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,7 @@
 ---
 # defaults file for roles/lvm-partitions
 
+lvm_shrink: True
 lvm_lvopts:
+lvm_lvmount_dump: 1
+lvm_lvmount_passno: 2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,7 +22,7 @@
   mount:
     name: "{{ lvm_lvmount }}"
     src: /dev/{{ lvm_vgname }}/{{ lvm_lvname }}
-    dump: "1"
-    passno: "2"
+    dump: "{{ lvm_lvmount_dump | default(1) }}"
+    passno: "{{ lvm_lvmount_passno | default(2) }}"
     fstype: "{{ lvm_lvfilesystem }}"
     state: mounted

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,5 @@
 ---
+
 # Setup LVM partition
 
 - name: storage | create logical volume
@@ -7,8 +8,8 @@
     vg: "{{ lvm_vgname }}"
     lv: "{{ lvm_lvname }}"
     size: "{{ lvm_lvsize }}"
-    shrink: "{{ lvm_shrink | default(True) }}"
-    opts: "{{ lvm_lvopts | default(None) }}"
+    shrink: "{{ lvm_shrink }}"
+    opts: "{{ lvm_lvopts }}"
 
 - name: storage | format
   become: yes
@@ -22,7 +23,7 @@
   mount:
     name: "{{ lvm_lvmount }}"
     src: /dev/{{ lvm_vgname }}/{{ lvm_lvname }}
-    dump: "{{ lvm_lvmount_dump | default(1) }}"
-    passno: "{{ lvm_lvmount_passno | default(2) }}"
+    dump: "{{ lvm_lvmount_dump }}"
+    passno: "{{ lvm_lvmount_passno }}"
     fstype: "{{ lvm_lvfilesystem }}"
     state: mounted


### PR DESCRIPTION
Allows us to run this role against root partition (which currently would change the passno to '2', which should be '1' for `/`).