### PR TITLE
clarify task name (format -> filesystem)

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,7 @@
     shrink: "{{ lvm_shrink | default(True) }}"
     opts: "{{ lvm_lvopts | default(None) }}"
 
-- name: storage | format
+- name: storage | filesystem
   become: yes
   filesystem:
     fstype: "{{ lvm_lvfilesystem }}"


### PR DESCRIPTION
Format is a little misleading as we can have resize only here

It's a little unnerving to see "format" change when just changing e.g. filesystem size